### PR TITLE
Use `//`-comment on that line that contains '*/'

### DIFF
--- a/content-addressable.js
+++ b/content-addressable.js
@@ -15,9 +15,8 @@ you have the correct data no matter who give it to you.
 These features make building a distributed system very
 easy, and is why you see this pattern in git, bittorrent,
 and bitcoin.
-
-(try: ls .git/objects/*/* to look inside git's CA store)
 */
+// (try: ls .git/objects/*/* to look inside git's CA store)
 
 var fs = require('fs')
 var pull = require('pull-stream')


### PR DESCRIPTION
Github's syntax highlighting otherwise turns everything pretty red [like this](https://github.com/dominictarr/pull-stream-examples/blob/master/content-addressable.js):

> ![shot](https://cloud.githubusercontent.com/assets/5231746/13730607/84fe4ebc-e94b-11e5-8082-98af04681f90.png)
